### PR TITLE
Try new preview action with subdirectory

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,15 +1,7 @@
-# This file was created automatically with `myst init --gh-pages` 🪄 💚
-
-name: MyST GitHub Pages Deploy
+name: trigger-book-build
 on:
-  push:
-    # Runs on pushes targeting the default branch
-    branches: [main]
-  workflow_dispatch:
-env:
-  # `BASE_URL` determines the website is served from, including CSS & JS assets
-  # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
+  pull_request:
+
 defaults:
   run:
     shell: bash -leo pipefail {0}
@@ -24,10 +16,17 @@ concurrency:
   group: 'pages'
   cancel-in-progress: false
 jobs:
+  find-pull-request:
+    uses: ProjectPythia/cookbook-actions/.github/workflows/find-pull-request.yaml@main
   deploy:
+    needs: find-pull-request
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+        # `BASE_URL` determines the website is served from, including CSS & JS assets
+        # You may need to change this to `BASE_URL: ''`
+        BASE_URL: /${{ github.event.repository.name }}/_preview/${{ needs.find-pull-request.outputs.number }} # deploy to subdirectory labeled with PR number
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Seeing if we can deploy a myst site to a `_preview` subdirectory using the `BASE_URL` environment variable, without compromising the existing deployment.