### PR TITLE
Point to config file in projectpythia org

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -1,7 +1,7 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 extends:
-  - https://raw.githubusercontent.com/projectpythia-mystmd/pythia-config/main/pythia.yml
+  - https://raw.githubusercontent.com/projectpythia/pythia-config/main/pythia.yml
 project:
   title: Project Pythia Cookbook Template - Jupter Book 2
   github: https://github.com/projectpythia-mystmd/cookbook-template


### PR DESCRIPTION
The myst configuration now lives at https://github.com/ProjectPythia/pythia-config

This PR updates the `myst.yml` file in this repo to point to the correct config.